### PR TITLE
Updates to web GUI to work on other computers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ log/
 /rosdep/
 /rosinstall/
 ros_ws/log/latest_build
+
+jugglebot-gui-server.service

--- a/README.md
+++ b/README.md
@@ -22,13 +22,22 @@ You can also source the install directory if you'd like to have access to the RO
 echo "source $(pwd)/ros_ws/install/setup.bash" >> ~/.bashrc
 ```
 
-Use `jugglebot_build` to build the jugglebot ROS2 workspace natively. Use `jugglebot_build_docker` to build the same inside a docker container.
+Use `jugglebot_build` to build the jugglebot ROS2 workspace natively. Use `jugglebot_build_docker` to build the same inside a docker container. Use `jugglebot_clean` to clean up the install, build and logs directories.
+
+### GUI
+
+The GUI runs on a web server. This can be maually executed by running `http-server` in the `ros_ws/gui` directory, or a background server can be activated using `jugglebot_enable_server_service`. This only has to be run once and will start the server on startup and keep it alive.
 
 ### Dependencies
 
-Dependencies are managed using rosdep. Ensure you have a working rosdep setup using the following commands.
+#### Manual Dependencies
 
-```bash
-sudo rosdep init
-rosdep update
-```
+Install the latest ROS2 distribution compatible with your hardware using the official docs [here](https://docs.ros.org/en/iron/Releases.html).
+
+Install npm using the relevant tutorial for your system [here](https://nodejs.org/en/download/package-manager).
+
+#### Automated Dependencies
+
+Package dependencies are managed using apt, pip, rosdep and npm.
+
+Dependencies can be installed using the `install_jugglebot_dependencies` script.

--- a/ros_ws/gui/3dplotter.js
+++ b/ros_ws/gui/3dplotter.js
@@ -42,7 +42,7 @@ var gridHelper
 function initROS() {
     // Initialize ROS
     var ros = new ROSLIB.Ros({
-        url: 'ws://192.168.20.23:9090'
+        url : `ws://${window.location.hostname}:9090`
     });
 
     // Set up service client for /get_robot_geometry (to convert between coordinate frames)
@@ -583,7 +583,7 @@ export function initPlotter() {
 
     // Initialize scene, camera and renderer
     camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 10000);
-    renderer = new THREE.WebGLRenderer();
+    renderer = new THREE.WebGLRenderer({antialias: true});
     var container = document.getElementById("plot-3d");
     renderer.setSize(container.clientWidth, container.clientHeight);
     container.appendChild(renderer.domElement);

--- a/ros_ws/gui/README.md
+++ b/ros_ws/gui/README.md
@@ -1,8 +1,0 @@
-To start gui:
-
-$ ros2 launch rosbridge_server rosbridge_websocket_launch.xml
-
-
-To start server:
-http-server .
-(in /ros_ws/gui)

--- a/ros_ws/gui/index.html
+++ b/ros_ws/gui/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0; url=jugglebot_gui.html" />
+    </head>
+</html>

--- a/ros_ws/gui/main.js
+++ b/ros_ws/gui/main.js
@@ -6,7 +6,7 @@ window.onload = function () {
     // ################################################################## //
 
     var ros = new ROSLIB.Ros({
-        url : 'ws://192.168.20.23:9090'
+        url : `ws://${window.location.hostname}:9090`
     });
 
     ros.on('connection', function() {

--- a/ros_ws/src/jugglebot/launch/jugglebot_launch.py
+++ b/ros_ws/src/jugglebot/launch/jugglebot_launch.py
@@ -1,9 +1,9 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
-# from launch.actions import ExecuteProcess, IncludeLaunchDescription
-# from launch.launch_description_sources import PythonLaunchDescriptionSource, AnyLaunchDescriptionSource
-# from ament_index_python.packages import get_package_share_directory
-# import os
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+from ament_index_python.packages import get_package_share_directory
+import os
 
 def generate_launch_description():
     nodes = [
@@ -18,11 +18,11 @@ def generate_launch_description():
     ]
 
     # # Path to the rosbridge_websocket_launch.xml file
-    # rosbridge_launch_file_path = os.path.join(
-    #     get_package_share_directory('rosbridge_server'),
-    #     'launch',
-    #     'rosbridge_websocket_launch.xml'
-    # )
+    rosbridge_launch_file_path = os.path.join(
+        get_package_share_directory('rosbridge_server'),
+        'launch',
+        'rosbridge_websocket_launch.xml'
+    )
 
     return LaunchDescription([
         # # Begin by starting the server that serves the http files to the browser
@@ -34,9 +34,9 @@ def generate_launch_description():
         # ),
 
         # # Now start the rosbridge websocket to allow the ROS network to communicate with the GUI
-        # IncludeLaunchDescription(
-        #     AnyLaunchDescriptionSource(rosbridge_launch_file_path)
-        # ),
+        IncludeLaunchDescription(
+            AnyLaunchDescriptionSource(rosbridge_launch_file_path)
+        ),
 
         # Finally, start the ROS network itself
         *[

--- a/scripts/jugglebot_clean
+++ b/scripts/jugglebot_clean
@@ -4,6 +4,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cd $SCRIPT_DIR/../ros_ws
 
-colcon build
+rm -rf build install log
 
 cd -

--- a/scripts/jugglebot_enable_server_service
+++ b/scripts/jugglebot_enable_server_service
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+JUGGLEBOT_DIR=$(realpath $SCRIPT_DIR/..)
+sed "s|<JUGGLEBOT_DIR>|$JUGGLEBOT_DIR|" $SCRIPT_DIR/services/jugglebot-gui-server.service.template > $SCRIPT_DIR/services/jugglebot-gui-server.service
+
+sudo systemctl enable $SCRIPT_DIR/services/jugglebot-gui-server.service
+sudo systemctl restart jugglebot-gui-server.service

--- a/scripts/jugglebot_install_dependencies
+++ b/scripts/jugglebot_install_dependencies
@@ -1,0 +1,30 @@
+#!/usr/bin/bash -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+echo ""
+echo "Installing apt dependencies..."
+echo "=============================="
+sudo apt-get update
+sudo apt-get install \
+    libhidapi-dev
+
+echo ""
+echo "Installing npm dependencies..."
+echo "=============================="
+cd $SCRIPT_DIR/../ros_ws/gui
+sudo npm install --global http-server
+npm install
+cd -
+
+echo ""
+echo "Installing rosdep dependencies..."
+echo "=============================="
+sudo rosdep init || true
+rosdep update
+rosdep install --from-paths $SCRIPT_DIR/../ros_ws/src -y --ignore-src
+
+echo ""
+echo "Installing python dependencies..."
+echo "=============================="
+pip install -r $SCRIPT_DIR/requirements.txt

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+pyspacemouse==1.1.0

--- a/scripts/services/jugglebot-gui-server.service.template
+++ b/scripts/services/jugglebot-gui-server.service.template
@@ -1,0 +1,18 @@
+[Unit]
+Description=Jugglebot GUI Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=<JUGGLEBOT_DIR>/ros_ws/gui
+ExecStart=http-server
+
+Restart=always
+RestartSec=3
+
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Some updates for the GUI. You described some issues with putting the socket server in the launch file, it works fine for me so I'm not certain on your issue. Give this a try and let me know if it doesn't work. I'm sure it'll be something simple.

Changes:

- add jugglebot_clean to clean ROS build artefacts
- update readme
- add dynamic hostname to ROS websocket so it doesn't depend on specific IPs
- add antialiasing to 3D view for smooth lines
- add index.html and redirect to GUI so you go straight to the GUI
- add rosbridge to launch file
- add jugglebot_enable_server_service script to create a background service to keep the webserver running and start it on boot
- add jugglebot_install_dependencies for all the different dependencies